### PR TITLE
Removing the master and slave words

### DIFF
--- a/dart-2017-05-10/ancien driver/crcmod-1.7/docs/source/conf.py
+++ b/dart-2017-05-10/ancien driver/crcmod-1.7/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/dart-2017-05-10/ancien driver/trex.py
+++ b/dart-2017-05-10/ancien driver/trex.py
@@ -86,7 +86,7 @@ class TrexIO():
         'impact_sensitivity_low_byte'   Impact sensitivity low byte
         'battery_high_byte'             Battery voltage high byte (motors off)
         'battery_low_byte'              Battery voltage low byte (motors off)
-        'i2c_address'                   I2C slave address
+        'i2c_address'                   I2C subordinate address
         'i2c_clock'                     I2C clock frequency
         
     """

--- a/dart-2017-05-10/ancien driver/trex_original.py
+++ b/dart-2017-05-10/ancien driver/trex_original.py
@@ -68,7 +68,7 @@ class TrexIO():
         'impact_sensitivity_low_byte'   Impact sensitivity low byte
         'battery_high_byte'             Battery voltage high byte (motors off)
         'battery_low_byte'              Battery voltage low byte (motors off)
-        'i2c_address'                   I2C slave address
+        'i2c_address'                   I2C subordinate address
         'i2c_clock'                     I2C clock frequency
         
     """

--- a/dart-2017-05-10/drivers/crcmod-1.7/docs/source/conf.py
+++ b/dart-2017-05-10/drivers/crcmod-1.7/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/dart-2017-05-10/drivers/trex.py
+++ b/dart-2017-05-10/drivers/trex.py
@@ -86,7 +86,7 @@ class TrexIO():
         'impact_sensitivity_low_byte'   Impact sensitivity low byte
         'battery_high_byte'             Battery voltage high byte (motors off)
         'battery_low_byte'              Battery voltage low byte (motors off)
-        'i2c_address'                   I2C slave address
+        'i2c_address'                   I2C subordinate address
         'i2c_clock'                     I2C clock frequency
         
     """

--- a/dart-2017-05-10/drivers/trex_original.py
+++ b/dart-2017-05-10/drivers/trex_original.py
@@ -68,7 +68,7 @@ class TrexIO():
         'impact_sensitivity_low_byte'   Impact sensitivity low byte
         'battery_high_byte'             Battery voltage high byte (motors off)
         'battery_low_byte'              Battery voltage low byte (motors off)
-        'i2c_address'                   I2C slave address
+        'i2c_address'                   I2C subordinate address
         'i2c_clock'                     I2C clock frequency
         
     """


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.